### PR TITLE
Add initial AOC 2022 Setup for Elixir

### DIFF
--- a/2022/elixir/aoc/.formatter.exs
+++ b/2022/elixir/aoc/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/2022/elixir/aoc/.gitignore
+++ b/2022/elixir/aoc/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+aoc-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/2022/elixir/aoc/.tool-versions
+++ b/2022/elixir/aoc/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.14.2-otp-25
+erlang 25.0

--- a/2022/elixir/aoc/README.md
+++ b/2022/elixir/aoc/README.md
@@ -1,0 +1,21 @@
+# Aoc
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `aoc` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:aoc, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/aoc>.
+

--- a/2022/elixir/aoc/lib/aoc.ex
+++ b/2022/elixir/aoc/lib/aoc.ex
@@ -1,0 +1,24 @@
+defmodule Aoc do
+  @moduledoc """
+  Documentation for `Aoc`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> Aoc.hello()
+      :world
+
+  """
+  @spec hello() :: atom()
+  def hello do
+    :world
+  end
+
+  @spec hello(name: String.t()) :: String.t()
+  def hello(name) do
+    "Hello there, #{name}"
+  end
+end

--- a/2022/elixir/aoc/mix.exs
+++ b/2022/elixir/aoc/mix.exs
@@ -1,0 +1,29 @@
+defmodule Aoc.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :aoc,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/2022/elixir/aoc/mix.lock
+++ b/2022/elixir/aoc/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
+}

--- a/2022/elixir/aoc/test/aoc_test.exs
+++ b/2022/elixir/aoc/test/aoc_test.exs
@@ -1,0 +1,8 @@
+defmodule AocTest do
+  use ExUnit.Case
+  doctest Aoc
+
+  test "greets the world" do
+    assert Aoc.hello() == :world
+  end
+end

--- a/2022/elixir/aoc/test/test_helper.exs
+++ b/2022/elixir/aoc/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
 - create 2022 directory
 - create initial Elixir project `mix new`
 - setup dialyxir for dialyzer
 - add elixir .tool_versions